### PR TITLE
Renamed PauseWriterThreshold parameter

### DIFF
--- a/IceRpc/Transports/Slic/Internal/SlicDefinitions.slice
+++ b/IceRpc/Transports/Slic/Internal/SlicDefinitions.slice
@@ -67,8 +67,7 @@ unchecked enum ParameterKey : varuint62 {
     /// The maximum packet size in bytes.
     PacketMaxSize = 3
 
-    /// The initial stream window size. The peer should hold off sending data when the stream window size is 0. It
-    /// should resume sending after receiving the {@link FrameType::StreamWindowUpdate} frame.
+    /// The initial stream window size.
     InitialStreamWindowSize = 4
 }
 


### PR DESCRIPTION
See https://github.com/icerpc/icerpc-csharp/issues/3316

I'm replacing PauseWriterThreshold/ResumeWriterThreshold with a unique window size property. One question is whether or not this property should be called `StreamReceiveWindowSize` or `InitialStreamReceiveWindowSize`. Today, the former is better suited since we use a fixed window size... if tomorrow we implement dynamic window size, the later will be better suited. 

I choose to go for the `StreamReceiveWindowSize`.