### PR TITLE
Update doc-comments in Object.ice

### DIFF
--- a/IceRpc/Ice/Object.ice
+++ b/IceRpc/Ice/Object.ice
@@ -2,25 +2,25 @@
 
 #pragma once
 
-// This Slice file should be considered internal to IceRPC, but with public generated code.
+// This file should be considered internal to IceRPC, but with public generated code.
 // It allows us to use the code generator to map the operations of the pseudo base interface Object.
 
 ["cs:identifier:IceRpc.Ice"]
 module Ice
 {
-    /// A sequence of strings representing Slice type IDs.
+    /// A sequence of strings representing Ice type IDs.
     sequence<string> TypeIdSeq;
 
-    /// Represents the implicit base interface of all Slice interfaces.
+    /// Base interface with common operations.
     ["cs:identifier:IceObject"]
     interface \Object
     {
-        /// Gets the Slice type IDs of all the interfaces implemented by the target service.
-        /// @return The Slice type IDs of all these interfaces, sorted alphabetically.
+        /// Gets the Ice type IDs of all the interfaces implemented by the target service.
+        /// @return The Ice type IDs of all these interfaces, sorted alphabetically.
         idempotent TypeIdSeq ice_ids();
 
         /// Tests whether the target service implements the specified interface.
-        /// @param id The Slice type ID of the interface to test against.
+        /// @param id The Ice type ID of the interface to test against.
         /// @return True when the target service implements this interface; otherwise, false.
         idempotent bool ice_isA(string id);
 


### PR DESCRIPTION
This PR reworks the doc-comments to avoid using "Slice" for Ice definitions in IceRPC.